### PR TITLE
Updated to work with version 1.3.1 of Posts 2 Posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 P2P-WPML
 ========
 
-**p2p-wpml** is a [Wordpress](http://wordpress.org/) plugin that integrates [iCanLocalize's WPML](http://wpml.org/) and [Posts 2 Posts](http://scribu.net/wordpress/posts-to-posts).
-This plugin has been only tested with Wordpress version 3.2.1, WPML version 2.3.3 and 2.3.4, and Posts 2 Posts version 0.8; different versions of Wordpress or the plugins may break this plugin's functionality so use it at your own risk.
+**p2p-wpml** is a [WordPress](http://wordpress.org/) plugin that integrates [iCanLocalize's WPML](http://wpml.org/) and [Posts 2 Posts](http://scribu.net/wordpress/posts-to-posts).
+
+This plugin has been tested with WordPress version 3.4.1, WPML version 2.5.2, and Posts 2 Posts version 1.3.1. Earlier versions of the Posts 2 Posts are not compatible with this plugin.
 
 Features
 --------
@@ -21,7 +22,7 @@ Features
 Installation
 ------------
 
-1. Extract the downloadable archive inside *wp-content/plugins*, and activate in Wordpress administration.
+1. Extract the downloadable archive inside *wp-content/plugins*, and activate in WordPress administration.
 1. The plugin can be configured accessing the **Posts 2 Posts** link inside the **WPML** settings menu.
 
 **IMPORTANT**: 

--- a/p2p-wpml.php
+++ b/p2p-wpml.php
@@ -2,8 +2,8 @@
 /*
 Plugin Name: Posts 2 Posts - WPML integration
 Description: A plugin for integrating Posts 2 Posts and WPML, solving some inconsistencies
-Version: 1.0
-Author: Lorenzo Carrara <lorenzo.carrara@cubica.eu>
+Version: 1.1
+Author: Lorenzo Carrara, Twinpictures, Baden03
 Author URI: http://www.cubica.eu
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === p2p-wpml === 
-Contributors: lencinhaus
+Contributors: lencinhaus, baden03, twinpictures
 Tags: p2p, wpml, sitepress, icanlocalize, posts-to-posts, posts-2-posts, posts to posts, posts-to-posts
 Requires at least: 3.2.1
-Tested up to: 3.2.1
-Stable tag: 1.0
+Tested up to: 3.4.1
+Stable tag: 1.1
 
 Integration between WPML and Posts 2 Posts.
 
@@ -31,7 +31,7 @@ This plugin has been only tested with Wordpress version 3.2.1, WPML version 2.3.
 * Currently this plugin doesn't manage multiple connections between the same posts (a single connection will be created between the translated posts).
 * Currently the synchronization feature is NOT retroactive: all connections created before plugin activation will not be synchronized (it can still be done manually as without the plugin).
 
-Links: [**Github**](https://github.com/cubica/p2p-wpml) | [Author's Site](http://www.cubica.eu)
+Links: [**Github**](https://github.com/cubica/p2p-wpml) | [Author's Site](http://www.cubica.eu) | [Twinpictures](http://plugins.twinpictures.de)
 
 == Installation ==
 
@@ -52,10 +52,15 @@ Answer
 1. Settings management
 
 == Changelog ==
- 
+
+= 1.1 = 
+* Correctly loads the ui.js script for p2p v.1.3.1+
+
 = 1.0 = 
 * First version 
 
-== Upgrade Notice == 
+== Upgrade Notice ==
+= 1.0 =
+Updated to work with p2p v.1.3.1+
 = 1.0 =
 First version

--- a/readme.txt
+++ b/readme.txt
@@ -9,9 +9,9 @@ Integration between WPML and Posts 2 Posts.
 
 == Description ==
 
-**p2p-wpml** is a [Wordpress](http://wordpress.org/) plugin that integrates [iCanLocalize's WPML](http://wpml.org/) and [Posts 2 Posts](http://scribu.net/wordpress/posts-to-posts).
+**p2p-wpml** is a [WordPress](http://wordpress.org/) plugin that integrates [iCanLocalize's WPML](http://wpml.org/) and [Posts 2 Posts](http://scribu.net/wordpress/posts-to-posts).
 
-This plugin has been only tested with Wordpress version 3.2.1, WPML version 2.3.3 and 2.3.4, and Posts 2 Posts version 0.8; different versions of Wordpress or the plugins may break this plugin's functionality so use it at your own risk.
+This plugin has been tested with WordPress version 3.4.1, WPML version 2.5.2, and Posts 2 Posts version 1.3.1. Earlier versions of the Posts 2 Posts are not compatible with this plugin.
 
 = Features =
 
@@ -35,7 +35,7 @@ Links: [**Github**](https://github.com/cubica/p2p-wpml) | [Author's Site](http:/
 
 == Installation ==
 
-1. Extract the downloadable archive inside *wp-content/plugins*, and activate in Wordpress administration.
+1. Extract the downloadable archive inside *wp-content/plugins*, and activate in WordPress administration.
 1. The plugin can be configured accessing the **Posts 2 Posts** link inside the **WPML** settings menu.
 
 **IMPORTANT**: 

--- a/ui/ui.php
+++ b/ui/ui.php
@@ -6,6 +6,6 @@ class P2P_WPML_UI {
 	}
 	
 	public static function register_js() {
-		wp_enqueue_script( 'p2p-wpml-admin', plugins_url( 'ui.js', __FILE__ ), array( 'p2p-admin' ), '0.8', true );
+		wp_enqueue_script( 'p2p-wpml-admin', plugins_url( 'ui.js', __FILE__ ), array( 'p2p-box' ), '0.8', true );
 	}
 }


### PR DESCRIPTION
I forked and updated the plugin to work with WP 3.4.1, WPML 2.5.2 and Posts2Posts 1.3.1.  p2p-wpml v1.0 was not compatible with v1.3.1 of p2p due to the way the ui.js was being loaded using wp_enqueue_script.  This has been fixed in this pull request.
