### PR TITLE
Compatibly with P2P 1.4.3 and WordPress 3.5

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -4,10 +4,11 @@ class P2P_WPML_Admin {
 	const SETTINGS_GROUP = 'p2p_wpml_settings';
 	const SYNCHRONIZE_OPTION_NAME = 'p2p_wpml_synchronize';
 	const SYNCHRONIZE_METADATA_OPTION_NAME = 'p2p_wpml_synchronize_metadata';
-	const FILTER_OPTION_NAME = 'p2p_wpml_filter';
+	const SYNCHRONIZE_CONNECTIONS_OPTION_NAME = 'p2p_wpml_synchronize_connections';
 	const DEFAULT_SYNCHRONIZE = '0';
 	const DEFAULT_SYNCHRONIZE_METADATA = '0';
-	const DEFAULT_FILTER = '1';
+	const DEFAULT_SYNCHRONIZE_CONNECTIONS = '0';
+	
 	const WEBSITE_URL = 'https://github.com/cubica/p2p-wpml';
 	
 	public static function init() {
@@ -25,12 +26,12 @@ class P2P_WPML_Admin {
 	public static function register_settings() {
 		register_setting( self::SETTINGS_GROUP, self::SYNCHRONIZE_OPTION_NAME );
 		register_setting( self::SETTINGS_GROUP, self::SYNCHRONIZE_METADATA_OPTION_NAME );
-		register_setting( self::SETTINGS_GROUP, self::FILTER_OPTION_NAME );
+		register_setting( self::SETTINGS_GROUP, self::SYNCHRONIZE_CONNECTIONS_OPTION_NAME );
 
 		add_settings_section('p2p-wpml-section', 'P2P WPML Settings', array(__CLASS__, 'get_settings_section_text'), __FILE__);
 		add_settings_field(self::SYNCHRONIZE_OPTION_NAME, 'Synchronize connections between translations', array(__CLASS__, 'create_synchronize_setting_field'), __FILE__, 'p2p-wpml-section');
 		add_settings_field(self::SYNCHRONIZE_METADATA_OPTION_NAME, 'Synchronize connection metadata between translations', array(__CLASS__, 'create_synchronize_metadata_setting_field'), __FILE__, 'p2p-wpml-section');
-		add_settings_field(self::FILTER_OPTION_NAME, 'Filter connectable items by current language', array(__CLASS__, 'create_filter_setting_field'), __FILE__, 'p2p-wpml-section');
+		add_settings_field(self::SYNCHRONIZE_CONNECTIONS_OPTION_NAME, 'Save Current P2P connections to Database', array(__CLASS__, 'create_synchronize_connections_setting_field'), __FILE__, 'p2p-wpml-section');
 	}
 	
 	public static function get_settings_section_text() {
@@ -45,8 +46,8 @@ class P2P_WPML_Admin {
 		echo self::create_checkbox_setting_field(self::SYNCHRONIZE_METADATA_OPTION_NAME, self::shouldSynchronizeMetadata());
 	}
 	
-	public static function create_filter_setting_field() {
-		echo self::create_checkbox_setting_field(self::FILTER_OPTION_NAME, self::shouldFilter());
+	public static function create_synchronize_connections_setting_field() {
+		echo self::create_checkbox_setting_field(self::SYNCHRONIZE_CONNECTIONS_OPTION_NAME, self::shouldSynchronizeConnections());
 	}
 	
 	private static function create_checkbox_setting_field($optionName, $value) {
@@ -78,7 +79,9 @@ class P2P_WPML_Admin {
 		return get_option(self::SYNCHRONIZE_METADATA_OPTION_NAME, self::DEFAULT_SYNCHRONIZE_METADATA) === '1';
 	}
 	
-	public static function shouldFilter() {
-		return get_option(self::FILTER_OPTION_NAME, self::DEFAULT_FILTER) === '1';
+	public static function shouldSynchronizeConnections() {
+		$connectionTypes = P2P_Connection_Type_Factory::get_all_instances();
+		update_option(self::SYNCHRONIZE_CONNECTIONS_OPTION_NAME, $connectionTypes);
+		return get_option(self::SYNCHRONIZE_CONNECTIONS_OPTION_NAME, self::DEFAULT_SYNCHRONIZE_CONNECTIONS) === $connectionTypes;
 	}
 }

--- a/p2p-wpml.php
+++ b/p2p-wpml.php
@@ -1,10 +1,12 @@
 <?php
 /*
 Plugin Name: Posts 2 Posts - WPML integration
+Plugin URI: https://github.com/cubica/p2p-wpml
 Description: A plugin for integrating Posts 2 Posts and WPML, solving some inconsistencies
-Version: 1.2.1
-Author: Lorenzo Carrara, Twinpictures, Baden03
+Version: 1.2.2
+Author: Lorenzo Carrara
 Author URI: http://www.cubica.eu
+License: GPL2
 */
 
 class P2P_WPML {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: lencinhaus, baden03, twinpictures
 Tags: p2p, wpml, sitepress, icanlocalize, posts-to-posts, posts-2-posts, posts to posts, posts-to-posts
 Requires at least: 3.2.1
-Tested up to: 3.4.1
-Stable tag: 1.2.1
+Tested up to: 3.6-alpha
+Stable tag: 1.2.2
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&encrypted=-----BEGIN+PKCS7-----MIIHXwYJKoZIhvcNAQcEoIIHUDCCB0wCAQExggEwMIIBLAIBADCBlDCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb20CAQAwDQYJKoZIhvcNAQEBBQAEgYApcJG9mmUhvVsZbZbMxwTs8tSBDdq1E%2biwo%2fmGEA3DKp1MaWO04urh%2bn5e7W8QA0VLT4PxClF7HtvetQZIxeCIhyghjPHEAu%2blLQKu660Crrbem8J2CMSCiwgPdIsWxivEStRA%2bKXJ%2fEafNUN3CT1W3o2%2bIY21sKoU1acsPy7LsTELMAkGBSsOAwIaBQAwgdwGCSqGSIb3DQEHATAUBggqhkiG9w0DBwQInnGO1bQx5jKAgbhOgr%2bWRywvJo9Ey9SPB%2b90JUxX2zAFgdJrGM2%2fgW%2f5WIybb6zd%2baQgslt2NdwbcfXLOO93rVH6DBrFViIpkc6CKo0Pc6hZFimFASx%2b%2fRgnhU8eIRMnhTU41htTrS7mXvyu9zxMPzBrBC5xEbP3g765dImA0C50nn49RpMUoy9SZseEd8VFIdu1F%2baxxscNvMBXNTQSPqx6rNOtS9pYR%2btNv6cF%2be6X3uACe0kD9OCT7WJbJKOH%2bM6ioIIDhzCCA4MwggLsoAMCAQICAQAwDQYJKoZIhvcNAQEFBQAwgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMB4XDTA0MDIxMzEwMTMxNVoXDTM1MDIxMzEwMTMxNVowgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBR07d%2fETMS1ycjtkpkvjXZe9k%2b6CieLuLsPumsJ7QC1odNz3sJiCbs2wC0nLE0uLGaEtXynIgRqIddYCHx88pb5HTXv4SZeuv0Rqq4%2baxW9PLAAATU8w04qqjaSXgbGLP3NmohqM6bV9kZZwZLR%2fklDaQGo1u9uDb9lr4Yn%2brBQIDAQABo4HuMIHrMB0GA1UdDgQWBBSWn3y7xm8XvVk%2fUtcKG%2bwQ1mSUazCBuwYDVR0jBIGzMIGwgBSWn3y7xm8XvVk%2fUtcKG%2bwQ1mSUa6GBlKSBkTCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb22CAQAwDAYDVR0TBAUwAwEB%2fzANBgkqhkiG9w0BAQUFAAOBgQCBXzpWmoBa5e9fo6ujionW1hUhPkOBakTr3YCDjbYfvJEiv%2f2P%2bIobhOGJr85%2bXHhN0v4gUkEDI8r2%2frNk1m0GA8HKddvTjyGw%2fXqXa%2bLSTlDYkqI8OwR8GEYj4efEtcRpRYBxV8KxAW93YDWzFGvruKnnLbDAF6VR5w%2fcCMn5hzGCAZowggGWAgEBMIGUMIGOMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxFDASBgNVBAoTC1BheVBhbCBJbmMuMRMwEQYDVQQLFApsaXZlX2NlcnRzMREwDwYDVQQDFAhsaXZlX2FwaTEcMBoGCSqGSIb3DQEJARYNcmVAcGF5cGFsLmNvbQIBADAJBgUrDgMCGgUAoF0wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTIwNzAyMTQ0MjUzWjAjBgkqhkiG9w0BCQQxFgQU%2fO57bo%2bU1YOo%2fAvKmUSDJZwZ9lUwDQYJKoZIhvcNAQEBBQAEgYC%2fcYrtAf7hPZi4eY9JfrPNeZZ5MtKLHJzAQOfLYhJKEfdUTZnTwKcAWq%2bLgherkB6LKqWIqUE9bvkQeDUSHNZVkMqtH3MFimEfJ6odm%2bIm6uGXz1s92ukyNjKtVvjdg4oE%2fnDJ%2bycyIzMBHiWRTPe%2b5rWsdwQe4BOYbY0bID8UAA%3d%3d-----END+PKCS7-----
 
 Integration between WPML and Posts 2 Posts.
@@ -26,11 +26,17 @@ The following table shows version compatibility between this plugin, other plugi
 	* WPML 2.5.2
 	* Wordpress 3.4.1
 
-* P2P-WPML 1.2.x
+* P2P-WPML 1.2.1
 
 	* P2P 1.4.1
 	* WPML 2.5.2
 	* Wordpress 3.4.1
+
+* P2P-WPML 1.2.2
+
+	* P2P 1.4.3
+	* WPML 2.6.2
+	* Wordpress 3.5
 	
 This plugin has been only tested with the above version combinations; different versions of Wordpress or the plugins may break this plugin's functionality so use it at your own risk.
 
@@ -79,6 +85,9 @@ Answer
 
 == Changelog ==
 
+= 1.2.2 =
+* Compatibility with P2P 1.4.3
+
 = 1.2.1 =
 * Fixed notices, see issue https://github.com/cubica/p2p-wpml/issues/7
 
@@ -96,3 +105,10 @@ Answer
 
 = 1.0 = 
 * First version
+
+== Upgrade Notice ==
+
+= 1.2.2 =
+* Compatibility with WordPress 3.5
+* WPML 2.6.2
+* P2P 1.4.3

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: lencinhaus, baden03, twinpictures
 Tags: p2p, wpml, sitepress, icanlocalize, posts-to-posts, posts-2-posts, posts to posts, posts-to-posts
 Requires at least: 3.2.1
-Tested up to: 3.6-alpha
-Stable tag: 1.2.2
+Tested up to: 3.6-beta
+Stable tag: 1.2.3
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&encrypted=-----BEGIN+PKCS7-----MIIHXwYJKoZIhvcNAQcEoIIHUDCCB0wCAQExggEwMIIBLAIBADCBlDCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb20CAQAwDQYJKoZIhvcNAQEBBQAEgYApcJG9mmUhvVsZbZbMxwTs8tSBDdq1E%2biwo%2fmGEA3DKp1MaWO04urh%2bn5e7W8QA0VLT4PxClF7HtvetQZIxeCIhyghjPHEAu%2blLQKu660Crrbem8J2CMSCiwgPdIsWxivEStRA%2bKXJ%2fEafNUN3CT1W3o2%2bIY21sKoU1acsPy7LsTELMAkGBSsOAwIaBQAwgdwGCSqGSIb3DQEHATAUBggqhkiG9w0DBwQInnGO1bQx5jKAgbhOgr%2bWRywvJo9Ey9SPB%2b90JUxX2zAFgdJrGM2%2fgW%2f5WIybb6zd%2baQgslt2NdwbcfXLOO93rVH6DBrFViIpkc6CKo0Pc6hZFimFASx%2b%2fRgnhU8eIRMnhTU41htTrS7mXvyu9zxMPzBrBC5xEbP3g765dImA0C50nn49RpMUoy9SZseEd8VFIdu1F%2baxxscNvMBXNTQSPqx6rNOtS9pYR%2btNv6cF%2be6X3uACe0kD9OCT7WJbJKOH%2bM6ioIIDhzCCA4MwggLsoAMCAQICAQAwDQYJKoZIhvcNAQEFBQAwgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMB4XDTA0MDIxMzEwMTMxNVoXDTM1MDIxMzEwMTMxNVowgY4xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUGF5UGFsIEluYy4xEzARBgNVBAsUCmxpdmVfY2VydHMxETAPBgNVBAMUCGxpdmVfYXBpMRwwGgYJKoZIhvcNAQkBFg1yZUBwYXlwYWwuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBR07d%2fETMS1ycjtkpkvjXZe9k%2b6CieLuLsPumsJ7QC1odNz3sJiCbs2wC0nLE0uLGaEtXynIgRqIddYCHx88pb5HTXv4SZeuv0Rqq4%2baxW9PLAAATU8w04qqjaSXgbGLP3NmohqM6bV9kZZwZLR%2fklDaQGo1u9uDb9lr4Yn%2brBQIDAQABo4HuMIHrMB0GA1UdDgQWBBSWn3y7xm8XvVk%2fUtcKG%2bwQ1mSUazCBuwYDVR0jBIGzMIGwgBSWn3y7xm8XvVk%2fUtcKG%2bwQ1mSUa6GBlKSBkTCBjjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtQYXlQYWwgSW5jLjETMBEGA1UECxQKbGl2ZV9jZXJ0czERMA8GA1UEAxQIbGl2ZV9hcGkxHDAaBgkqhkiG9w0BCQEWDXJlQHBheXBhbC5jb22CAQAwDAYDVR0TBAUwAwEB%2fzANBgkqhkiG9w0BAQUFAAOBgQCBXzpWmoBa5e9fo6ujionW1hUhPkOBakTr3YCDjbYfvJEiv%2f2P%2bIobhOGJr85%2bXHhN0v4gUkEDI8r2%2frNk1m0GA8HKddvTjyGw%2fXqXa%2bLSTlDYkqI8OwR8GEYj4efEtcRpRYBxV8KxAW93YDWzFGvruKnnLbDAF6VR5w%2fcCMn5hzGCAZowggGWAgEBMIGUMIGOMQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxFDASBgNVBAoTC1BheVBhbCBJbmMuMRMwEQYDVQQLFApsaXZlX2NlcnRzMREwDwYDVQQDFAhsaXZlX2FwaTEcMBoGCSqGSIb3DQEJARYNcmVAcGF5cGFsLmNvbQIBADAJBgUrDgMCGgUAoF0wGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTIwNzAyMTQ0MjUzWjAjBgkqhkiG9w0BCQQxFgQU%2fO57bo%2bU1YOo%2fAvKmUSDJZwZ9lUwDQYJKoZIhvcNAQEBBQAEgYC%2fcYrtAf7hPZi4eY9JfrPNeZZ5MtKLHJzAQOfLYhJKEfdUTZnTwKcAWq%2bLgherkB6LKqWIqUE9bvkQeDUSHNZVkMqtH3MFimEfJ6odm%2bIm6uGXz1s92ukyNjKtVvjdg4oE%2fnDJ%2bycyIzMBHiWRTPe%2b5rWsdwQe4BOYbY0bID8UAA%3d%3d-----END+PKCS7-----
 
 Integration between WPML and Posts 2 Posts.
@@ -12,33 +12,39 @@ Integration between WPML and Posts 2 Posts.
 
 **p2p-wpml** is a [WordPress](http://wordpress.org/) plugin that integrates [iCanLocalize's WPML](http://wpml.org/) and [Posts 2 Posts](http://scribu.net/wordpress/posts-to-posts).
 
-The following table shows version compatibility between this plugin, other plugins and Wordpress:
+The following table shows version compatibility between this plugin, other plugins and WordPress:
 
 * P2P-WPML 1.0
 
 	* P2P 0.8
 	* WPML 2.3.3, 2.3.4
-	* Wordpress 3.2.1
+	* WordPress 3.2.1
 
 * P2P-WPML 1.1
 
 	* P2P 1.3.1
 	* WPML 2.5.2
-	* Wordpress 3.4.1
+	* WordPress 3.4.1
 
 * P2P-WPML 1.2.1
 
 	* P2P 1.4.1
 	* WPML 2.5.2
-	* Wordpress 3.4.1
+	* WordPress 3.4.1
 
 * P2P-WPML 1.2.2
 
 	* P2P 1.4.3
 	* WPML 2.6.2
-	* Wordpress 3.5
+	* WordPress 3.5
+
+* P2P-WPML 1.2.3
+
+	* P2P 1.5.2
+	* WPML 2.7.1
+	* WordPress 3.5.1
 	
-This plugin has been only tested with the above version combinations; different versions of Wordpress or the plugins may break this plugin's functionality so use it at your own risk.
+This plugin has been only tested with the above version combinations; different versions of WordPress or the plugins may break this plugin's functionality so use it at your own risk.
 
 = Features =
 
@@ -85,6 +91,10 @@ Answer
 
 == Changelog ==
 
+= 1.2.3 =
+* Compatibility with P2P 1.5.2, WPML 2.7.1 and WordPress 3.5.1
+* Added ability to synchronize connections on post duplication
+
 = 1.2.2 =
 * Compatibility with P2P 1.4.3
 
@@ -107,6 +117,11 @@ Answer
 * First version
 
 == Upgrade Notice ==
+= 1.2.3 =
+* Compatibility with WordPress 3.5.1
+* Compatibility with P2P 1.5.2
+* Compatibility with WPML 2.7.1
+* Finally: The ability to synchronize connections on post duplication
 
 = 1.2.2 =
 * Compatibility with WordPress 3.5

--- a/synchronizer.php
+++ b/synchronizer.php
@@ -144,8 +144,8 @@ class P2P_WPML_Synchronizer {
 			foreach($connectionTypes as $connectionTypeName => $connectionType) {
 				$connections = array();
 				
-				$isFromPost = $connectionType->object['from'] == 'post';
-				$isToPost = $connectionType->object['to'] == 'post';
+				$isFromPost = $connectionType->side['from'];
+				$isToPost = $connectionType->side['to'];
 				
 				if($isFromPost) {
 					// get the connections originating from the source translation

--- a/synchronizer.php
+++ b/synchronizer.php
@@ -268,8 +268,8 @@ class P2P_WPML_Synchronizer {
 		$tuples = array();
 		
 		$typeObj = p2p_type($connection->p2p_type);
-		$isFromPost = $typeObj->object['from'] == 'post';
-		$isToPost = $typeObj->object['to'] == 'post';
+		$isFromPost = $typeObj->side['from'];
+		$isToPost = $typeObj->side['to'];
 		$isFromTranslated = $isFromPost && self::is_post_translated($connection->p2p_from);
 		$isToTranslated = $isToPost && self::is_post_translated($connection->p2p_to);
 		

--- a/synchronizer.php
+++ b/synchronizer.php
@@ -1,7 +1,6 @@
 <?php
 class P2P_WPML_Synchronizer {
 	private static $editedPostIds = array();
-	
 	private static $inHandler = false;
 	
 	public static function init() {
@@ -13,8 +12,12 @@ class P2P_WPML_Synchronizer {
 			// add a edit_post action for catching post editing
 			add_action('edit_post', array(__CLASS__, 'edit_post'), 20, 1);
 			
+			// add a sync_post action for catching post creation
+			//add_action('icl_make_duplicate', array(__CLASS__, 'sync_post'), 10, 4);
+			
 			// add a save_post action for catching post creation
 			add_action('save_post', array(__CLASS__, 'save_post'), 20, 2);
+			
 			
 			// include auto-draft posts in p2p capture queries, so that synchronized connections appear
 			// when the translated post is in auto-draft status
@@ -26,6 +29,7 @@ class P2P_WPML_Synchronizer {
 			add_action('added_p2p_meta', array(__CLASS__, 'synchronize_added_metadata'), 20, 4);
 			add_action('deleted_p2p_meta', array(__CLASS__, 'synchronize_deleted_metadata'), 20, 4);
 			add_action('updated_p2p_meta', array(__CLASS__, 'synchronize_updated_metadata'), 20, 4);
+			
 		}
 	}
 	
@@ -39,7 +43,6 @@ class P2P_WPML_Synchronizer {
 		if(empty($connection)) return;
 		
 		$translatedConnectionIds = self::get_translated_connection_ids($connection);
-		
 		foreach($translatedConnectionIds as $translatedConnectionId) {
 			p2p_add_meta($translatedConnectionId, $key, $value);
 		}
@@ -58,7 +61,7 @@ class P2P_WPML_Synchronizer {
 		
 		foreach($translatedConnectionIds as $translatedConnectionId) {
 			p2p_delete_meta($translatedConnectionId, $key, $value);
-		}
+			}
 	}
 	
 	public static function synchronize_updated_metadata($metaIds, $connectionId, $key, $value) {
@@ -69,9 +72,9 @@ class P2P_WPML_Synchronizer {
 		// get the connection
 		$connection = p2p_get_connection($connectionId);
 		if(empty($connection)) return;
-	
+		
 		$translatedConnectionIds = self::get_translated_connection_ids($connection);
-	
+		
 		foreach($translatedConnectionIds as $translatedConnectionId) {
 			p2p_update_meta($translatedConnectionId, $key, $value);
 		}
@@ -93,6 +96,15 @@ class P2P_WPML_Synchronizer {
 	
 	public static function edit_post($postId) {
 		self::$editedPostIds[] = $postId;
+	}
+	
+	//public static function save_post($postId, $post) {
+	public static function sync_post($master_post_id, $lang, $postarr, $id) {
+		//self::exec_safe('save_post_internal', $postId, $post);
+		$connectionTypes = P2P_Connection_Type_Factory::get_all_instances();
+		if(empty($connectionTypes)){
+			$connectionTypes = get_option('p2p_wpml_synchronize_connections');
+		}
 	}
 	
 	public static function save_post($postId, $post) {
@@ -140,7 +152,9 @@ class P2P_WPML_Synchronizer {
 			
 			// get connection types
 			$connectionTypes = P2P_Connection_Type_Factory::get_all_instances();
-			
+			if(empty($connectionTypes)){
+				$connectionTypes = get_option('p2p_wpml_synchronize_connections');
+			}
 			foreach($connectionTypes as $connectionTypeName => $connectionType) {
 				$connections = array();
 				
@@ -266,10 +280,11 @@ class P2P_WPML_Synchronizer {
 	
 	private static function get_translated_tuples(&$connection) {
 		$tuples = array();
-		
 		$typeObj = p2p_type($connection->p2p_type);
+
 		$isFromPost = $typeObj->side['from'];
 		$isToPost = $typeObj->side['to'];
+		
 		$isFromTranslated = $isFromPost && self::is_post_translated($connection->p2p_from);
 		$isToTranslated = $isToPost && self::is_post_translated($connection->p2p_to);
 		
@@ -280,8 +295,8 @@ class P2P_WPML_Synchronizer {
 				foreach($fromTranslationIds as $lang => $fromTranslationId) {
 					if(isset($toTranslationIds[$lang])) {
 						$tuples[] = array(
-							'from' => $fromTranslationId,
-							'to' => $toTranslationIds[$lang]
+										  'from' => $fromTranslationId,
+										  'to' => $toTranslationIds[$lang]
 						);
 					}
 				}
@@ -381,7 +396,7 @@ class P2P_WPML_Synchronizer {
 	private static function exec_safe() {
 		if(self::$inHandler === true) return null;
 		self::$inHandler = true;
-		
+
 		$args = func_get_args();
 		$function = array_shift($args);
 		$result = call_user_func_array(array(__CLASS__, $function), $args);


### PR DESCRIPTION
This update will allow the plugin to keep connections in sync on WP 3.5 using WPML 2.6.2 and P2P 1.4.3 (even when WordPress is in Debug mode!).  Will now try to solve the issue of syncing connections when the post is duplicated.  Let me know what you think!
-Baden
