### PR TITLE
Directory name agnostic plugin dependency check, Fixes compatibility, fixes duplication of posts, fixes users connections

### DIFF
--- a/p2p-wpml.php
+++ b/p2p-wpml.php
@@ -8,41 +8,56 @@ Author URI: http://www.cubica.eu
 */
 
 class P2P_WPML {
-	private static $REQUIRED_PLUGINS = array(
-		'sitepress-multilingual-cms/sitepress.php',
-		'posts-to-posts/posts-to-posts.php'
-	);
+
+    public function run () {
+
+        // checks that WPML is installed and activated
+        if( ! defined('ICL_SITEPRESS_VERSION') ) return;
+
+        // init our plugin on the p2p_init action hook
+        add_action('p2p_init', array(__CLASS__, 'init') );
+
+        // shows admin notices
+        add_action('admin_notices', array(__CLASS__,'admin_notices') );
+
+    }
 	
 	public static function init() {
-		if(self::checkRequiredPlugins()) {
-			$basePath = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
-			require_once $basePath . 'ui' . DIRECTORY_SEPARATOR . 'ui.php';
-			require_once $basePath . 'synchronizer.php';
-			require_once $basePath . 'admin.php';
-				
-			// initialize classes
-			P2P_WPML_UI::init();
-			P2P_WPML_Synchronizer::init();
-			P2P_WPML_Admin::init();
-		}
-		else {
-			add_action('admin_init', array(__CLASS__, 'add_missing_plugins_warning'));
-		}
-	}
-	
-	public static function add_missing_plugins_warning() {
-		echo '<div class="error"><p><strong>P2P-WPML: in order to use this plugin, both WPML and Posts to Posts must be installed and activated</p></div>';
-	}
-	
-	private static function checkRequiredPlugins() {
-		if(!function_exists('is_plugin_active')) include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		
-		foreach(self::$REQUIRED_PLUGINS as $plugin) {
-			if(!is_plugin_active($plugin)) return false;
-		} 
-		
-		return true;
-	}
-}
 
-add_action('init', array('P2P_WPML', 'init'));
+		$basePath = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+		require_once $basePath . 'ui' . DIRECTORY_SEPARATOR . 'ui.php';
+		require_once $basePath . 'synchronizer.php';
+		require_once $basePath . 'admin.php';
+				
+		// initialize classes
+		P2P_WPML_UI::init();
+		P2P_WPML_Synchronizer::init();
+		P2P_WPML_Admin::init();
+
+        do_action('p2p_wmpl_init');
+	}
+
+    function admin_notices () {
+
+        // display only on plugins page
+        if( $GLOBALS['hook_suffix'] !== 'plugins.php' ) return;
+
+        // could init our plugin, no mnotice to display
+        if( did_action('p2p_wmpl_init') ) return;
+
+        // wpml not installed and activated
+        if( ! defined('ICL_SITEPRESS_VERSION') )
+            $message = sprintf( __('Posts 2 Posts - WPML integration plugin is enabled but not effective. It requires <a href="%s" target="_blank">WPML</a> in order to work.', 'p2p_wpml'), 'http://wpml.org/' );
+
+        // p2p not installed and activated
+        else
+            $message = sprintf( __('Posts 2 Posts - WPML integration plugin is enabled but not effective. It requires <a href="%s" target="_blank">Posts 2 Posts</a> in order to work.', 'p2p_wpml'), 'http://wordpress.org/plugins/posts-to-posts/' );
+        ?>
+        <div class="message error">
+            <p><?php echo $message; ?></p>
+        </div>
+    <?php
+
+    }
+}
+add_action('plugins_loaded', array('P2P_WPML', 'run'));

--- a/p2p-wpml.php
+++ b/p2p-wpml.php
@@ -15,7 +15,12 @@ class P2P_WPML {
         if( ! defined('ICL_SITEPRESS_VERSION') ) return;
 
         // init our plugin on the p2p_init action hook
-        add_action('p2p_init', array(__CLASS__, 'init') );
+        if(isset($_REQUEST['icl_ajx_action']) && function_exists('_p2p_init') ){
+            add_action('init', array(__CLASS__, 'early_init') );
+        }
+        else {
+            add_action('p2p_init', array(__CLASS__, 'init') );
+        }
 
         // shows admin notices
         add_action('admin_notices', array(__CLASS__,'admin_notices') );
@@ -36,6 +41,11 @@ class P2P_WPML {
 
         do_action('p2p_wmpl_init');
 	}
+
+    public static function early_init () {
+        _p2p_init();
+        self::init();
+    }
 
     function admin_notices () {
 

--- a/synchronizer.php
+++ b/synchronizer.php
@@ -144,8 +144,8 @@ class P2P_WPML_Synchronizer {
 			foreach($connectionTypes as $connectionTypeName => $connectionType) {
 				$connections = array();
 				
-				$isFromPost = $connectionType->object['from'] == 'post';
-				$isToPost = $connectionType->object['to'] == 'post';
+				$isFromPost = $connectionType->side['from'];
+				$isToPost = $connectionType->side['to'];
 				
 				if($isFromPost) {
 					// get the connections originating from the source translation

--- a/synchronizer.php
+++ b/synchronizer.php
@@ -161,7 +161,7 @@ class P2P_WPML_Synchronizer {
 						$metadata = p2p_get_meta($fromConnection->p2p_id);
 						
 						//check if the destination post is translated
-						if($isToPost && self::is_post_translated($toPostId)) {
+						if($isToPost && 'users' !== $connectionTypeName && self::is_post_translated($toPostId)) {
 							$toTranslationIds = self::get_post_translation_ids($toPostId);
 							if(isset($toTranslationIds[$lang])) $connections[] = array(
 								'from' => $postId,
@@ -271,7 +271,7 @@ class P2P_WPML_Synchronizer {
 		$isFromPost = $typeObj->side['from'];
 		$isToPost = $typeObj->side['to'];
 		$isFromTranslated = $isFromPost && self::is_post_translated($connection->p2p_from);
-		$isToTranslated = $isToPost && self::is_post_translated($connection->p2p_to);
+		$isToTranslated = $isToPost && 'users' !== $connection->p2p_type && self::is_post_translated($connection->p2p_to);
 		
 		if($isFromTranslated) {
 			$fromTranslationIds = self::get_post_translation_ids($connection->p2p_from);

--- a/synchronizer.php
+++ b/synchronizer.php
@@ -268,8 +268,8 @@ class P2P_WPML_Synchronizer {
 		$tuples = array();
 		
 		$typeObj = p2p_type($connection->p2p_type);
-		$isFromPost = $typeObj->object['from'] == 'post';
-		$isToPost = $typeObj->object['to'] == 'post';
+		$isFromPost = $typeObj->side['from'];
+		$isToPost = $typeObj->side['to'];
 		$isFromTranslated = $isFromPost && self::is_post_translated($connection->p2p_from);
 		$isToTranslated = $isToPost && self::is_post_translated($connection->p2p_to);
 		


### PR DESCRIPTION
Compatibility fixes are from @baden03

I modified the way the plugin checks for other plugins being activated. This modification does not rely anymore on the dependent plugins to be installed in a specifically named folder.

Then, in order to fix duplicated posts, I noticed that the duplicate ajax action was done at the init hook by WPML, but P2P inits itself later (at the wp_loaded hook). I so implemented a little hack to init P2P and P2P-WPML earlier in case of a WPML Ajax request.

Lastly, users connections synchronization was buggy because the plugin was looking for translated post to users using user's IDs ... I fixed it.
