### PR TITLE
Changes init hook priority for the hack handling duplicates

### DIFF
--- a/p2p-wpml.php
+++ b/p2p-wpml.php
@@ -19,7 +19,7 @@ class P2P_WPML {
             add_action('init', array(__CLASS__, 'early_init') );
         }
         else {
-            add_action('p2p_init', array(__CLASS__, 'init') );
+            add_action('p2p_init', array(__CLASS__, 'init'), 14 );
         }
 
         // shows admin notices


### PR DESCRIPTION
As Wordpress Codex tells to init custom post_types at the init hook, I had another look to the WPML code.

They are definitely handling their ajax the wrong way (Wordpress has specific hooks for that), but they are doing it at the init hook at the priority 15.

So, to be sure (most) custom post type have been initialized before we init P2P using that hack, it is better to do it as late as possible, but before WPML does its ajax thing: the priority 14 is the best we can do.

As it can cause problems with plugins that define custom post types, I think this change deserve another point release.
