### PR TITLE
Fix connection ordering/meta not syncing across languages.

### DIFF
--- a/synchronizer.php
+++ b/synchronizer.php
@@ -253,12 +253,12 @@ class P2P_WPML_Synchronizer {
 		
 		$connectionIds = array();
 		foreach($tuples as $tuple) {
-			$connectionIds += p2p_get_connections($connection->p2p_type, array(
+			$connectionIds = array_merge($connectionIds, p2p_get_connections($connection->p2p_type, array(
 				'direction' => 'from',
 				'from' => $tuple['from'],
 				'to' => $tuple['to'],
 				'fields' => 'p2p_id'
-			));
+			)));
 		}
 		
 		return array_unique($connectionIds);


### PR DESCRIPTION
Been battling with this issue for a while and was finally able to debug it.

The get_translated_connection_ids() method was incorrectly only returning one ID instead of an array of all translation IDs.

The p2p_get_connections() function returns an array of post IDs.  
Using `+=` to concatenate the values return to the `$connectionIds` array was failing and just returning the first array - according to the PHP documentation:

> The + operator returns the right-hand array appended to the left-hand array; for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored.

The values returned by `p2p_get_connections()` were just a non-associative array where the index would start at zero, so each time the arrays were combines with `+=` both arrays had a value at zero index so it just rented the first.

Using `array_merge()` to combine the returned arrays fixes the issue for me.
