### PR TITLE
Fix: syncronize connections for new translation

### DIFF
--- a/synchronizer.php
+++ b/synchronizer.php
@@ -191,7 +191,7 @@ class P2P_WPML_Synchronizer {
 					// translation in the current language
 					foreach($toConnections as $toConnection) {
 						$fromPostId = $toConnection->p2p_from;
-						$metadata = p2p_get_meta($fromConnection->p2p_id);
+						$metadata = p2p_get_meta($toConnection->p2p_id);
 						
 						//check if the origin post is translated
 						if($isFromPost && !is_a($isFromPost, 'P2P_Side_User') && self::is_post_translated($fromPostId)) {


### PR DESCRIPTION
Fix error `undefined variable fromConnection in /wp-content/plugins/p2p-wpml/synchonizer.php on line 194`.

Reproduce the error:
1. Create two custom post types and register a p2p connection.
2. Add new post (post_type_a) and set some connections to posts (post_type_b).
3. Add a translation to that post (post_type_a).
  - The error happens here.
  - The translated post (post_type_a) doesn't have any translated posts (post_type_b) connected.

After the fix the synchronization works. Tested in gutenberg.
WordPress 5.2.2
wpml 4.2.7.1
p2p--wpml 1.2.5
